### PR TITLE
Annotation RollingUpdateMaxUnavailable need to be copied to subscription deployable

### DIFF
--- a/pkg/apis/app/v1alpha1/subscription_types.go
+++ b/pkg/apis/app/v1alpha1/subscription_types.go
@@ -30,6 +30,8 @@ var (
 	AnnotationSyncSource = SchemeGroupVersion.Group + "/sync-source"
 	// AnnotationRollingUpdateTarget target deployable to rolling update to
 	AnnotationRollingUpdateTarget = SchemeGroupVersion.Group + "/rollingupdate-target"
+	// AnnotationRollingUpdateMaxUnavailable defines max un available clusters during rolling update
+	AnnotationRollingUpdateMaxUnavailable = SchemeGroupVersion.Group + "/rollingupdate-maxunavaialble"
 	// AnnotationDeployables defines all deployables subscribed by the subscription
 	AnnotationDeployables = SchemeGroupVersion.Group + "/deployables"
 	// AnnotationHosting defines the subscription hosting the resource

--- a/pkg/controller/mcmhub/hub.go
+++ b/pkg/controller/mcmhub/hub.go
@@ -341,7 +341,7 @@ func (r *ReconcileSubscription) clearSubscriptionDpls(sub *appv1alpha1.Subscript
 		// no longer hub, check owner-reference and delete if it is generated.
 		owners := hubdpl.GetOwnerReferences()
 		for _, owner := range owners {
-			if owner.Name == sub.Name {
+			if owner.UID == sub.UID {
 				err = r.Delete(context.TODO(), hubdpl)
 				if err != nil {
 					klog.V(5).Infof("Error in deleting sbuscription target deploayble: %#v, err: %#v ", hubdpl, err)
@@ -368,7 +368,7 @@ func (r *ReconcileSubscription) clearSubscriptionTargetDpl(sub *appv1alpha1.Subs
 		// check owner-reference and delete if it is generated.
 		owners := hubTargetDpl.GetOwnerReferences()
 		for _, owner := range owners {
-			if owner.Name == sub.Name {
+			if owner.UID == sub.UID {
 				err = r.Delete(context.TODO(), hubTargetDpl)
 				if err != nil {
 					klog.Infof("Error in deleting sbuscription target deploayble: %#v, err: %v", hubTargetDpl, err)


### PR DESCRIPTION
1. Annotation RollingUpdateMaxUnavailable need to be copied to subscription deployable
2. expired  subscription deployables failed to delete as the UID for the same subscription deployables could change.