### PR TITLE
Versioncontrol

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/ghodss/yaml v1.0.1-0.20180820084758-c7ce16629ff4
 	github.com/go-openapi/spec v0.19.0
+	github.com/google/go-cmp v0.3.1
 	github.com/onsi/gomega v1.5.0
 	github.com/operator-framework/operator-sdk v0.12.0
 	github.com/prometheus/common v0.4.1

--- a/pkg/utils/version.go
+++ b/pkg/utils/version.go
@@ -162,6 +162,8 @@ func IsDeployableInVersionSet(vMap map[string]VersionRep, dpl *dplv1alpha1.Deplo
 	vdplKey := types.NamespacedName{Name: dpl.Name, Namespace: dpl.Namespace}.String()
 	dplAnno := dpl.GetAnnotations()
 
+	klog.V(5).Infof("version map %v, dplkey %v", vMap, vdplKey)
+
 	_, versionField := dplAnno[dplv1alpha1.AnnotationDeployableVersion]
 
 	dplGroup := dpl.GetGenerateName()

--- a/pkg/utils/version.go
+++ b/pkg/utils/version.go
@@ -142,6 +142,7 @@ func emptyVersionsField(curDpl *dplv1alpha1.Deployable, vset map[string]VersionR
 			}
 		}
 	}
+
 	return vset
 }
 

--- a/pkg/utils/version.go
+++ b/pkg/utils/version.go
@@ -160,9 +160,12 @@ func DplArrayToDplPointers(dplList []dplv1alpha1.Deployable) []*dplv1alpha1.Depl
 // IsDeployableInVersionSet - check if deployable is in version
 func IsDeployableInVersionSet(vMap map[string]VersionRep, dpl *dplv1alpha1.Deployable) bool {
 	vdplKey := types.NamespacedName{Name: dpl.Name, Namespace: dpl.Namespace}.String()
+	dplAnno := dpl.GetAnnotations()
+
+	_, versionField := dplAnno[dplv1alpha1.AnnotationDeployableVersion]
 
 	dplGroup := dpl.GetGenerateName()
-	if dplGroup == "" {
+	if dplGroup == "" || !versionField {
 		dplGroup = dpl.GetName()
 	}
 

--- a/pkg/utils/version.go
+++ b/pkg/utils/version.go
@@ -62,7 +62,7 @@ func SemverCheck(vSubStr, vDplStr string) bool {
 // VersionRep represent version
 type VersionRep struct {
 	DplKey string
-	vrange string
+	Vrange string
 }
 
 //GenerateVersionSet produce a map, key: dpl.GetGenerateName(), value: dpl.NamespacedName.String()
@@ -72,6 +72,14 @@ func GenerateVersionSet(dplPointers []*dplv1alpha1.Deployable, vsub string) map[
 
 	for _, curDpl := range dplPointers {
 		vcurDpl := curDpl.GetAnnotations()[dplv1alpha1.AnnotationDeployableVersion]
+
+		// if the deployable doesn't have a version string, then treat it a the base verion of it's own
+		// version group, meaning using the dpl name as group key
+		if len(vcurDpl) == 0 {
+			vset = emptyVersionsField(curDpl, vset)
+			continue
+		}
+
 		vmatch := SemverCheck(vsub, vcurDpl)
 
 		if !vmatch {
@@ -88,29 +96,52 @@ func GenerateVersionSet(dplPointers []*dplv1alpha1.Deployable, vsub string) map[
 		}
 
 		r := "%s%s"
-		// if the deployable doesn't have a version string, then treat it a the base verion
-		if len(vcurDpl) == 0 {
-			vcurDpl = "0.0.0"
-		}
 
 		vrangestr := fmt.Sprintf(r, ">", vcurDpl)
 
 		if preDpl, ok := vset[DplGroupName]; !ok {
 			vset[DplGroupName] = VersionRep{
 				DplKey: curDplKey,
-				vrange: vrangestr,
+				Vrange: vrangestr,
 			}
 		} else {
-			preRange := preDpl.vrange
+			preRange := preDpl.Vrange
 			if SemverCheck(preRange, vcurDpl) {
 				vset[DplGroupName] = VersionRep{
 					DplKey: curDplKey,
-					vrange: vrangestr,
+					Vrange: vrangestr,
 				}
 			}
 		}
 	}
 
+	return vset
+}
+
+func emptyVersionsField(curDpl *dplv1alpha1.Deployable, vset map[string]VersionRep) map[string]VersionRep {
+	DplGroupName := curDpl.GetName()
+
+	r := "%s%s"
+	// if the deployable doesn't have a version string, then treat it a the base verion
+	vcurDpl := "0.0.0"
+
+	vrangestr := fmt.Sprintf(r, ">", vcurDpl)
+	curDplKey := types.NamespacedName{Name: curDpl.Name, Namespace: curDpl.Namespace}.String()
+
+	if preDpl, ok := vset[DplGroupName]; !ok {
+		vset[DplGroupName] = VersionRep{
+			DplKey: curDplKey,
+			Vrange: vrangestr,
+		}
+	} else {
+		preRange := preDpl.Vrange
+		if SemverCheck(preRange, vcurDpl) {
+			vset[DplGroupName] = VersionRep{
+				DplKey: curDplKey,
+				Vrange: vrangestr,
+			}
+		}
+	}
 	return vset
 }
 

--- a/pkg/utils/version_test.go
+++ b/pkg/utils/version_test.go
@@ -21,8 +21,9 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	dplv1alpha1 "github.com/IBM/multicloud-operators-deployable/pkg/apis/app/v1alpha1"
 	"github.com/google/go-cmp/cmp"
+
+	dplv1alpha1 "github.com/IBM/multicloud-operators-deployable/pkg/apis/app/v1alpha1"
 )
 
 type versionTest struct {
@@ -143,7 +144,7 @@ func TestGenerateVersionSetWithVersionInfo(t *testing.T) {
 	}
 }
 
-//While version info is empty, we will treat them as seperate resouces, in which
+//While version info is empty, we will treat them as separate resouces, in which
 // we will use the name instead of the generate name for the key of the version set
 func TestGenerateVersionSetWithEmptyVersionInfo(t *testing.T) {
 	groupA := "A"
@@ -168,10 +169,10 @@ func TestGenerateVersionSetWithEmptyVersionInfo(t *testing.T) {
 			dpls:    []*dplv1alpha1.Deployable{&dpl4, &dpl5, &dpl4b, &dpl5b},
 			vstring: "",
 			versionSet: map[string]VersionRep{
-				"dpl4":  VersionRep{DplKey: "/dpl4", Vrange: ">0.0.0"},
-				"dpl5":  VersionRep{DplKey: "/dpl5", Vrange: ">0.0.0"},
-				"dpl4b": VersionRep{DplKey: "/dpl4b", Vrange: ">0.0.0"},
-				"dpl5b": VersionRep{DplKey: "/dpl5b", Vrange: ">0.0.0"},
+				"dpl4":  {DplKey: "/dpl4", Vrange: ">0.0.0"},
+				"dpl5":  {DplKey: "/dpl5", Vrange: ">0.0.0"},
+				"dpl4b": {DplKey: "/dpl4b", Vrange: ">0.0.0"},
+				"dpl5b": {DplKey: "/dpl5b", Vrange: ">0.0.0"},
 			},
 		},
 		{
@@ -179,10 +180,10 @@ func TestGenerateVersionSetWithEmptyVersionInfo(t *testing.T) {
 			dpls:    []*dplv1alpha1.Deployable{&dpl4, &dpl4b, &dpl2, &dpl2b},
 			vstring: "",
 			versionSet: map[string]VersionRep{
-				"dpl4":  VersionRep{DplKey: "/dpl4", Vrange: ">0.0.0"},
-				"dpl4b": VersionRep{DplKey: "/dpl4b", Vrange: ">0.0.0"},
-				groupA:  VersionRep{DplKey: "/dpl2", Vrange: ">2.0.0"},
-				"dpl2b": VersionRep{DplKey: "/dpl2b", Vrange: ">2.0.0"},
+				"dpl4":  {DplKey: "/dpl4", Vrange: ">0.0.0"},
+				"dpl4b": {DplKey: "/dpl4b", Vrange: ">0.0.0"},
+				groupA:  {DplKey: "/dpl2", Vrange: ">2.0.0"},
+				"dpl2b": {DplKey: "/dpl2b", Vrange: ">2.0.0"},
 			},
 		},
 	}
@@ -196,7 +197,6 @@ func TestGenerateVersionSetWithEmptyVersionInfo(t *testing.T) {
 }
 
 func assertVersionSet(t *testing.T, got, want map[string]VersionRep) {
-
 	if diff := cmp.Diff(got, want); diff != "" {
 		t.Errorf("GenerateVersionSet got error: got %v, want %v", got, want)
 		t.Errorf("MakeGatewayInfo() mismatch (-want +got):\n%s", diff)

--- a/pkg/utils/version_test.go
+++ b/pkg/utils/version_test.go
@@ -22,6 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	dplv1alpha1 "github.com/IBM/multicloud-operators-deployable/pkg/apis/app/v1alpha1"
+	"github.com/google/go-cmp/cmp"
 )
 
 type versionTest struct {
@@ -80,25 +81,20 @@ func generateFakeDpl(generateName, name, version string) dplv1alpha1.Deployable 
 	}
 }
 
-func TestGenerateVersionSet(t *testing.T) {
+func TestGenerateVersionSetWithVersionInfo(t *testing.T) {
 	groupA := "A"
+	groupB := ""
+
 	dpl1 := generateFakeDpl(groupA, "dpl1", "1.0.0")
 	dpl2 := generateFakeDpl(groupA, "dpl2", "2.0.0")
 	dpl3 := generateFakeDpl(groupA, "dpl3", "1.8.0")
-	dpl4 := generateFakeDpl(groupA, "dpl4", "")
-	dpl5 := generateFakeDpl(groupA, "dpl5", "")
 
-	groupB := ""
 	dpl1b := generateFakeDpl(groupB, "dpl1b", "1.0.0")
 	dpl2b := generateFakeDpl(groupB, "dpl2b", "2.0.0")
 	dpl3b := generateFakeDpl(groupB, "dpl3b", "1.6.0")
 
 	test1 := []dplv1alpha1.Deployable{dpl1, dpl2, dpl3}
 	test2 := []dplv1alpha1.Deployable{dpl1, dpl2, dpl3}
-	test3 := []dplv1alpha1.Deployable{dpl4, dpl5}
-
-	test4 := []dplv1alpha1.Deployable{dpl4, dpl5}
-	test5 := []*dplv1alpha1.Deployable{&dpl4, &dpl5}
 
 	test6 := []dplv1alpha1.Deployable{dpl1b, dpl2b, dpl3b}
 
@@ -114,27 +110,6 @@ func TestGenerateVersionSet(t *testing.T) {
 			vsub:     "",
 			dpllist:  DplArrayToDplPointers(test2),
 			result:   "/dpl2",
-		},
-
-		{
-			caseName: "3 subscription has a verion but deployables version is empty",
-			vsub:     "<2.1.0",
-			dpllist:  DplArrayToDplPointers(test3),
-			result:   "/dpl4",
-		},
-
-		{
-			caseName: "4 both subscription and deployable has empty version info",
-			vsub:     "",
-			dpllist:  DplArrayToDplPointers(test4),
-			result:   "/dpl4",
-		},
-
-		{
-			caseName: "5 subscription,deployable has empty version info, passing in deployable pointer",
-			vsub:     "",
-			dpllist:  test5,
-			result:   "/dpl4",
 		},
 	}
 
@@ -165,5 +140,65 @@ func TestGenerateVersionSet(t *testing.T) {
 				t.Errorf("wanted %#v, got %#v", c.result, got)
 			}
 		})
+	}
+}
+
+//While version info is empty, we will treat them as seperate resouces, in which
+// we will use the name instead of the generate name for the key of the version set
+func TestGenerateVersionSetWithEmptyVersionInfo(t *testing.T) {
+	groupA := "A"
+	groupB := ""
+
+	dpl2 := generateFakeDpl(groupA, "dpl2", "2.0.0")
+	dpl4 := generateFakeDpl(groupA, "dpl4", "")
+	dpl5 := generateFakeDpl(groupA, "dpl5", "")
+
+	dpl2b := generateFakeDpl(groupB, "dpl2b", "2.0.0")
+	dpl4b := generateFakeDpl(groupB, "dpl4b", "")
+	dpl5b := generateFakeDpl(groupB, "dpl5b", "")
+
+	testCases := []struct {
+		desc       string
+		dpls       []*dplv1alpha1.Deployable
+		vstring    string
+		versionSet map[string]VersionRep
+	}{
+		{
+			desc:    "empty version fields",
+			dpls:    []*dplv1alpha1.Deployable{&dpl4, &dpl5, &dpl4b, &dpl5b},
+			vstring: "",
+			versionSet: map[string]VersionRep{
+				"dpl4":  VersionRep{DplKey: "/dpl4", Vrange: ">0.0.0"},
+				"dpl5":  VersionRep{DplKey: "/dpl5", Vrange: ">0.0.0"},
+				"dpl4b": VersionRep{DplKey: "/dpl4b", Vrange: ">0.0.0"},
+				"dpl5b": VersionRep{DplKey: "/dpl5b", Vrange: ">0.0.0"},
+			},
+		},
+		{
+			desc:    "empty and valid version fields",
+			dpls:    []*dplv1alpha1.Deployable{&dpl4, &dpl4b, &dpl2, &dpl2b},
+			vstring: "",
+			versionSet: map[string]VersionRep{
+				"dpl4":  VersionRep{DplKey: "/dpl4", Vrange: ">0.0.0"},
+				"dpl4b": VersionRep{DplKey: "/dpl4b", Vrange: ">0.0.0"},
+				groupA:  VersionRep{DplKey: "/dpl2", Vrange: ">2.0.0"},
+				"dpl2b": VersionRep{DplKey: "/dpl2b", Vrange: ">2.0.0"},
+			},
+		},
+	}
+
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			got := GenerateVersionSet(tC.dpls, tC.vstring)
+			assertVersionSet(t, got, tC.versionSet)
+		})
+	}
+}
+
+func assertVersionSet(t *testing.T, got, want map[string]VersionRep) {
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("GenerateVersionSet got error: got %v, want %v", got, want)
+		t.Errorf("MakeGatewayInfo() mismatch (-want +got):\n%s", diff)
 	}
 }


### PR DESCRIPTION
Addressing the empty version field issue.

In addition, these codes will be reused by the object-store.

Helm and GitHub are following the same version logic check up flow.