### PR TITLE
remove setting of the helmrelease spec.releasename and change helmreleasecr name to use sub uid

### DIFF
--- a/deploy/olm-catalog/multicloud-operators-subscription/0.1.0/helmreleases.app.ibm.com.crd.yaml
+++ b/deploy/olm-catalog/multicloud-operators-subscription/0.1.0/helmreleases.app.ibm.com.crd.yaml
@@ -36,11 +36,6 @@ spec:
               description: Configuration parameters to access the helm-repo defined
                 in the CatalogSource
               type: object
-            releaseName:
-              description: ReleaseName is the Name of the release given to Tiller.
-                Defaults to namespace-name. Must not be changed after initial object
-                creation.
-              type: string
             secretRef:
               description: Secret to use to access the helm-repo defined in the CatalogSource.
               type: object

--- a/deploy/olm-catalog/multicloud-operators-subscription/0.1.0/multicloud-operators-subscription.v0.1.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/multicloud-operators-subscription/0.1.0/multicloud-operators-subscription.v0.1.0.clusterserviceversion.yaml
@@ -54,7 +54,6 @@ metadata:
           },
           "spec": {
             "chartName": "nginx-ingress",
-            "releaseName": "nginx-ingress",
             "source": {
               "helmRepo": {
                 "urls": [

--- a/deploy/standalone/app_v1alpha1_helmrelease_crd.yaml
+++ b/deploy/standalone/app_v1alpha1_helmrelease_crd.yaml
@@ -36,11 +36,6 @@ spec:
               description: Configuration parameters to access the helm-repo defined
                 in the CatalogSource
               type: object
-            releaseName:
-              description: ReleaseName is the Name of the release given to Tiller.
-                Defaults to namespace-name. Must not be changed after initial object
-                creation.
-              type: string
             secretRef:
               description: Secret to use to access the helm-repo defined in the CatalogSource.
               type: object

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/IBM/multicloud-operators-channel v0.0.0-20191106021206-61ab358c6b28
 	github.com/IBM/multicloud-operators-deployable v0.0.0-20191106030805-be79868c4e0f
 	github.com/IBM/multicloud-operators-placementrule v0.0.0-20191106021205-80eeda99597f
-	github.com/IBM/multicloud-operators-subscription-release v0.0.0-20191127022709-6dc2dc73dd87
+	github.com/IBM/multicloud-operators-subscription-release v0.0.0-20200127192841-d79fb0fd582b
 	github.com/aws/aws-sdk-go-v2 v0.15.0
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/ghodss/yaml v1.0.1-0.20180820084758-c7ce16629ff4

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/IBM/multicloud-operators-placementrule v0.0.0-20191106021205-80eeda99
 github.com/IBM/multicloud-operators-placementrule v0.0.0-20191106021205-80eeda99597f/go.mod h1:7cCjoormsMG/S1lDlmCjqRs4uwjCdsj9m5AwZHKQ0PQ=
 github.com/IBM/multicloud-operators-subscription-release v0.0.0-20191127022709-6dc2dc73dd87 h1:aL1s4e7gAyblgaBbRErvxml2J3Cq680usFRaxB4aV4I=
 github.com/IBM/multicloud-operators-subscription-release v0.0.0-20191127022709-6dc2dc73dd87/go.mod h1:KJfNoP7lqOC/uVh7z1oyz+EAdf+Iyqv29BG/JdaC7KU=
+github.com/IBM/multicloud-operators-subscription-release v0.0.0-20200127192841-d79fb0fd582b h1:AXpg8toM7w/DOF9lBIV7mQFIWSd+aJGpE9w4V9buOp8=
+github.com/IBM/multicloud-operators-subscription-release v0.0.0-20200127192841-d79fb0fd582b/go.mod h1:KJfNoP7lqOC/uVh7z1oyz+EAdf+Iyqv29BG/JdaC7KU=
 github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab/go.mod h1:3VYc5hodBMJ5+l/7J4xAyMeuM2PNuepvHlGs8yilUCA=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd h1:sjQovDkwrZp8u+gxLtPgKGjk5hCxuy2hrRejBTA9xFU=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=

--- a/hack/test/app_v1alpha1_helmrelease_crd.yaml
+++ b/hack/test/app_v1alpha1_helmrelease_crd.yaml
@@ -36,11 +36,6 @@ spec:
               description: Configuration parameters to access the helm-repo defined
                 in the CatalogSource
               type: object
-            releaseName:
-              description: ReleaseName is the Name of the release given to Tiller.
-                Defaults to namespace-name. Must not be changed after initial object
-                creation.
-              type: string
             secretRef:
               description: Secret to use to access the helm-repo defined in the CatalogSource.
               type: object

--- a/pkg/subscriber/helmrepo/subscriber_item.go
+++ b/pkg/subscriber/helmrepo/subscriber_item.go
@@ -35,7 +35,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	utilrand "k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/rest"
 	"k8s.io/helm/pkg/repo"
@@ -47,15 +46,6 @@ import (
 	appv1alpha1 "github.com/IBM/multicloud-operators-subscription/pkg/apis/app/v1alpha1"
 	kubesynchronizer "github.com/IBM/multicloud-operators-subscription/pkg/synchronizer/kubernetes"
 	"github.com/IBM/multicloud-operators-subscription/pkg/utils"
-)
-
-const (
-	//Max is 52 chars but as helm add behind the scene extension -delete-registrations for some objects
-	//The new limit is 31 chars
-	maxNameLength = 52 - len("-delete-registrations")
-	randomLength  = 5
-	//minus 1 because we add a dash
-	maxGeneratedNameLength = maxNameLength - randomLength - 1
 )
 
 // SubscriberItem - defines the unit of namespace subscription
@@ -499,8 +489,17 @@ func (hrsi *SubscriberItem) manageHelmCR(indexFile *repo.IndexFile, repoURL stri
 	for packageName, chartVersions := range indexFile.Entries {
 		klog.V(5).Infof("chart: %s\n%v", packageName, chartVersions)
 
-		releaseCRName := packageName + "-" + hrsi.Subscription.Name + "-" + hrsi.Subscription.Namespace
-		releaseName := packageName
+		releaseCRName := packageName
+		subUID := string(hrsi.Subscription.UID)
+
+		if len(subUID) >= 5 {
+			releaseCRName += "-" + subUID[:5]
+		}
+
+		releaseCRName, err := utils.GetReleaseName(releaseCRName)
+		if err != nil {
+			return err
+		}
 
 		helmRelease := &releasev1alpha1.HelmRelease{}
 		//Create a new helrmReleases
@@ -553,7 +552,6 @@ func (hrsi *SubscriberItem) manageHelmCR(indexFile *repo.IndexFile, repoURL stri
 						ConfigMapRef: hrsi.Channel.Spec.ConfigMapRef,
 						SecretRef:    hrsi.Channel.Spec.SecretRef,
 						ChartName:    packageName,
-						ReleaseName:  getReleaseName(releaseName),
 						Version:      chartVersions[0].GetVersion(),
 					},
 				}
@@ -576,12 +574,11 @@ func (hrsi *SubscriberItem) manageHelmCR(indexFile *repo.IndexFile, repoURL stri
 				ConfigMapRef: hrsi.Channel.Spec.ConfigMapRef,
 				SecretRef:    hrsi.Channel.Spec.SecretRef,
 				ChartName:    packageName,
-				ReleaseName:  releaseName,
 				Version:      chartVersions[0].GetVersion(),
 			}
 		}
 
-		err := hrsi.override(helmRelease)
+		err = hrsi.override(helmRelease)
 
 		if err != nil {
 			klog.Error("Failed to override ", helmRelease.Name, " err:", err)
@@ -640,16 +637,6 @@ func (hrsi *SubscriberItem) manageHelmCR(indexFile *repo.IndexFile, repoURL stri
 	}
 
 	return err
-}
-
-func getReleaseName(base string) string {
-	if len(base) > maxNameLength {
-		//minus 1 because adding "-"
-		base = base[:maxGeneratedNameLength]
-		return fmt.Sprintf("%s-%s", base, utilrand.String(randomLength))
-	}
-
-	return base
 }
 
 func (hrsi *SubscriberItem) override(helmRelease *releasev1alpha1.HelmRelease) error {


### PR DESCRIPTION
To compliment https://github.com/IBM/multicloud-operators-subscription-release/commit/d79fb0fd582bc5d8984f181a19c19f54e146fa68

- remove spec.releaseName from helmRelease CR
- helmRelease CR name is now packageName + first 5 characters of subscription uuid
- fix character limit function not producing a return that can be used consistently for update

Signed-off-by: Mike Ng <mikeshngdev@gmail.com>