### PR TITLE
add optional packageAlias to spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Spec:
   Channel:  dev/dev-helmrepo
   Name:     nginx-ingress
   Package Overrides:
+    Package Alias:  nginx-ingress-alias
     Package Name:  nginx-ingress
     Package Overrides:
       Path:   spec.values

--- a/deploy/crds/app.ibm.com_subscriptions_crd.yaml
+++ b/deploy/crds/app.ibm.com_subscriptions_crd.yaml
@@ -138,6 +138,8 @@ spec:
               items:
                 description: Overrides field in deployable
                 properties:
+                  packageAlias:
+                    type: string
                   packageName:
                     type: string
                   packageOverrides:

--- a/pkg/apis/app/v1alpha1/subscription_types.go
+++ b/pkg/apis/app/v1alpha1/subscription_types.go
@@ -70,7 +70,8 @@ type PackageOverride struct {
 
 // Overrides field in deployable
 type Overrides struct {
-	PackageName string `json:"packageName"`
+	PackageAlias string `json:"packageAlias,omitempty"`
+	PackageName  string `json:"packageName"`
 	// +kubebuilder:validation:MinItems=1
 	PackageOverrides []PackageOverride `json:"packageOverrides"` // To be added
 }


### PR DESCRIPTION
Add packageAlias to spec to allow package to be named. So for example, helmrelease will use that as its name if the alias is provided.